### PR TITLE
feat: Store 도메인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/ogiyo/store/controller/StoreController.java
+++ b/src/main/java/com/example/ogiyo/store/controller/StoreController.java
@@ -1,0 +1,72 @@
+package com.example.ogiyo.store.controller;
+
+import com.example.ogiyo.store.dto.request.CreateStoreRequestDto;
+import com.example.ogiyo.store.dto.request.UpdateStoreRequestDto;
+import com.example.ogiyo.store.dto.request.UpdateStoreStatusRequestDto;
+import com.example.ogiyo.store.dto.response.CreateStoreResponseDto;
+import com.example.ogiyo.store.dto.response.GetStoreResponseDto;
+import com.example.ogiyo.store.service.StoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/stores")
+@RequiredArgsConstructor
+public class StoreController {
+    private final StoreService storeService;
+
+    @GetMapping
+    public ResponseEntity<List<?>> findStores(@RequestParam(required = false) String storeName) {
+        return ResponseEntity.ok(storeService.findStores(storeName));
+    }
+
+    @GetMapping("/{storeId}")
+    public ResponseEntity<GetStoreResponseDto> findStore(@PathVariable Long storeId) {
+        return ResponseEntity.ok(storeService.findStoreById(storeId));
+    }
+
+    @PostMapping
+    public ResponseEntity<CreateStoreResponseDto> saveStore(@RequestBody CreateStoreRequestDto dto) {
+        CreateStoreResponseDto responseDto = storeService.saveStore(
+                dto.getStoreName(),
+                dto.getOperatingHours(),
+                dto.getAnnouncement(),
+                dto.getMinPrice(),
+                dto.getImageUrl());
+
+        URI location = URI.create("/api/v1/stores/" + responseDto.getStoreId());
+        return ResponseEntity.created(location).body(responseDto);
+    }
+
+    @PutMapping("/{storeId}")
+    public ResponseEntity<Void> updateStore(@PathVariable Long storeId, @RequestBody UpdateStoreRequestDto dto) {
+        storeService.updateStore(storeId,
+                dto.getStoreName(),
+                dto.getOperatingHours(),
+                dto.getAnnouncement(),
+                dto.getMinPrice(),
+                dto.getImageUrl());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{storeId}")
+    public ResponseEntity<Void> updateStoreStatus(@PathVariable Long storeId, @RequestBody UpdateStoreStatusRequestDto dto) {
+        storeService.updateStore(
+                storeId,
+                dto.getStatus());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    // UserAuth 추가
+    @DeleteMapping("/{storeId}")
+    public ResponseEntity<Void> deleteStore(@PathVariable Long storeId) {
+        storeService.deleteStore(storeId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/ogiyo/store/dto/request/CreateStoreRequestDto.java
+++ b/src/main/java/com/example/ogiyo/store/dto/request/CreateStoreRequestDto.java
@@ -1,0 +1,15 @@
+package com.example.ogiyo.store.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateStoreRequestDto {
+    private String storeName;
+    private String operatingHours;
+    private String announcement;
+//    private String tip;
+    private Long minPrice;
+    private String imageUrl;
+}

--- a/src/main/java/com/example/ogiyo/store/dto/request/UpdateStoreRequestDto.java
+++ b/src/main/java/com/example/ogiyo/store/dto/request/UpdateStoreRequestDto.java
@@ -1,0 +1,15 @@
+package com.example.ogiyo.store.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateStoreRequestDto {
+    private String storeName;
+    private String operatingHours;
+    private String announcement;
+    //    private String tip;
+    private Long minPrice;
+    private String imageUrl;
+}

--- a/src/main/java/com/example/ogiyo/store/dto/request/UpdateStoreStatusRequestDto.java
+++ b/src/main/java/com/example/ogiyo/store/dto/request/UpdateStoreStatusRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.ogiyo.store.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateStoreStatusRequestDto {
+    private String status;
+}

--- a/src/main/java/com/example/ogiyo/store/dto/response/CreateStoreResponseDto.java
+++ b/src/main/java/com/example/ogiyo/store/dto/response/CreateStoreResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.ogiyo.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateStoreResponseDto {
+    private Long storeId;
+    private String storeName;
+    private String status;
+}

--- a/src/main/java/com/example/ogiyo/store/dto/response/GetStoreResponseDto.java
+++ b/src/main/java/com/example/ogiyo/store/dto/response/GetStoreResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.ogiyo.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetStoreResponseDto {
+    private Long storeId;
+    private String storeName;
+    private String operatingHours;
+    private String announcement;
+    //    private String tip;
+    private Long minPrice;
+    private String imageUrl;
+    private String status;
+//    private List<Menu> menus;
+}

--- a/src/main/java/com/example/ogiyo/store/dto/response/GetStoresResponseDto.java
+++ b/src/main/java/com/example/ogiyo/store/dto/response/GetStoresResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.ogiyo.store.dto.response;
+
+import com.example.ogiyo.store.entity.Store;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GetStoresResponseDto {
+    private Long storeId;
+    private String storeName;
+    //    private String tip;
+    private Long minPrice;
+    private String imageUrl;
+    private String status;
+
+    public GetStoresResponseDto(Store store) {
+        this.storeId = store.getStoreId();
+        this.storeName = store.getStoreName();
+        this.minPrice = store.getMinPrice();
+        this.imageUrl = store.getImageUrl();
+        this.status = store.getStatus().toString();
+    }
+}

--- a/src/main/java/com/example/ogiyo/store/entity/Store.java
+++ b/src/main/java/com/example/ogiyo/store/entity/Store.java
@@ -1,0 +1,60 @@
+package com.example.ogiyo.store.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Store{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long storeId;
+
+    @Column(nullable = false)
+    private String storeName;
+
+    @Column(nullable = false)
+    private String operatingHours;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String announcement;
+
+    @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+    private Long minPrice;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+//    @OneToMany(mappedBy = "store", cascade = CascadeType.REMOVE, orphanRemoval = true)
+//    List<Menu> menus = new ArrayList<>();
+
+
+    public void updateStore(String storeName, String operatingHours, String announcement, Long minPrice, String imageUrl) {
+        this.storeName = storeName;
+        this.operatingHours = operatingHours;
+        this.announcement = announcement;
+        this.minPrice = minPrice;
+        this.imageUrl = imageUrl;
+    }
+
+    public void changeStatus(Status status) {
+        this.status = status;
+    }
+
+    public enum Status {
+        OPEN, CLOSED, PERMANENTLY_CLOSED
+    }
+}

--- a/src/main/java/com/example/ogiyo/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/ogiyo/store/repository/StoreRepository.java
@@ -1,0 +1,28 @@
+package com.example.ogiyo.store.repository;
+
+import com.example.ogiyo.store.dto.response.GetStoresResponseDto;
+import com.example.ogiyo.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Repository
+public interface StoreRepository extends JpaRepository<Store, Long> {
+//    @Query("SELECT s FROM Store s JOIN FETCH Menu m on m.store = s WHERE s.storeId = :storeId")
+//    Optional<Store> findById(@Param("storeId") Long storeId);
+
+    List<Store> findByStoreNameAndStatusNot(String storeName, Store.Status status);
+
+    default Store findByIdOrElseThrow(Long storeId) {
+        return findById(storeId).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Store Not Found"));
+    }
+
+    default List<GetStoresResponseDto> findByStoreNameToDto(String storeName) {
+        return findByStoreNameAndStatusNot(storeName, Store.Status.PERMANENTLY_CLOSED).stream()
+                .map(GetStoresResponseDto::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/ogiyo/store/service/StoreService.java
+++ b/src/main/java/com/example/ogiyo/store/service/StoreService.java
@@ -5,7 +5,9 @@ import com.example.ogiyo.store.dto.response.GetStoreResponseDto;
 import com.example.ogiyo.store.entity.Store;
 import com.example.ogiyo.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -69,6 +71,10 @@ public class StoreService {
 
     public void updateStore(Long storeId, String status) {
 
+        if (Store.Status.PERMANENTLY_CLOSED.toString().equals(status)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "폐업 할 수 없습니다.");
+        }
+
         Store savedStore = storeRepository.findByIdOrElseThrow(storeId);
 
         savedStore.changeStatus(Store.Status.valueOf(status));
@@ -77,8 +83,11 @@ public class StoreService {
     }
 
     public void deleteStore(Long storeId) {
+
         Store savedStore = storeRepository.findByIdOrElseThrow(storeId);
+
         savedStore.changeStatus(Store.Status.PERMANENTLY_CLOSED);
+
         storeRepository.save(savedStore);
     }
 }

--- a/src/main/java/com/example/ogiyo/store/service/StoreService.java
+++ b/src/main/java/com/example/ogiyo/store/service/StoreService.java
@@ -1,0 +1,84 @@
+package com.example.ogiyo.store.service;
+
+import com.example.ogiyo.store.dto.response.CreateStoreResponseDto;
+import com.example.ogiyo.store.dto.response.GetStoreResponseDto;
+import com.example.ogiyo.store.entity.Store;
+import com.example.ogiyo.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+    private final StoreRepository storeRepository;
+//    private final MenuService menuService; //추후 추가
+
+    public List<?> findStores(String storeName) {
+        if (storeName == null) {
+            return storeRepository.findAll();
+        }
+
+        return storeRepository.findByStoreNameToDto(storeName);
+    }
+
+    public GetStoreResponseDto findStoreById(Long storeId) {
+        Store savedStore = storeRepository.findByIdOrElseThrow(storeId);
+
+        return new GetStoreResponseDto(
+                savedStore.getStoreId(),
+                savedStore.getStoreName(),
+                savedStore.getOperatingHours(),
+                savedStore.getAnnouncement(),
+                savedStore.getMinPrice(),
+                savedStore.getImageUrl(),
+                savedStore.getStatus().toString());
+    }
+
+    public CreateStoreResponseDto saveStore(String storeName, String operatingHours, String announcement, Long minPrice, String imageUrl) {
+        // 메뉴 저장하는 부분 추후 추가
+        Store store = Store.builder()
+                .storeName(storeName)
+                .operatingHours(operatingHours)
+                .announcement(announcement)
+                .minPrice(minPrice)
+                .imageUrl(imageUrl)
+                .status(Store.Status.OPEN)
+                .build();
+
+        // 운영시간으로 영업, 마감, 폐업 선택
+
+        Store savedStore = storeRepository.save(store);
+        return new CreateStoreResponseDto(savedStore.getStoreId(), savedStore.getStoreName(), Store.Status.OPEN.toString());
+    }
+
+    public void updateStore(Long storeId, String storeName, String operatingHours, String announcement, Long minPrice, String imageUrl) {
+
+        Store savedStore = storeRepository.findByIdOrElseThrow(storeId);
+
+        savedStore.updateStore(
+                storeName,
+                operatingHours,
+                announcement,
+                minPrice,
+                imageUrl);
+
+        storeRepository.save(savedStore);
+    }
+
+    public void updateStore(Long storeId, String status) {
+
+        Store savedStore = storeRepository.findByIdOrElseThrow(storeId);
+
+        savedStore.changeStatus(Store.Status.valueOf(status));
+
+        storeRepository.save(savedStore);
+    }
+
+    public void deleteStore(Long storeId) {
+        Store savedStore = storeRepository.findByIdOrElseThrow(storeId);
+        savedStore.changeStatus(Store.Status.PERMANENTLY_CLOSED);
+        storeRepository.save(savedStore);
+    }
+}


### PR DESCRIPTION
```
Now
 - GET 단건 / 다건 조회 기능 추가 (상점의 상태 'OPEN / CLOSED / PERMANENTLY_CLOSED' 에 따라 조회 가능)
 - POST 상점 생성 기능 추가
 - PUT 상점 정보 업데이트 기능 추가
 - PATCH 상점 상태 정보 (OPEN / CLOSED) 업데이트 기능 추가
 - DELETE 상점 삭제 기능 (PERMANENTLY_CLOSED) 추가

ToDo
 - MenuService 가 추가되면 Store Entity 와 연관관계를 맺고 저장하는 기능 추가
 - S3 를 이용한 이미지 저장 기능 추가
 - 광고 Entity 추가 및 연관관계 설정
 - 주문 수량 Entity 연관관계 설정

```